### PR TITLE
Update show missing translations logic

### DIFF
--- a/lib/i18n_extension.dart
+++ b/lib/i18n_extension.dart
@@ -62,7 +62,7 @@ String localize(
     if (translatedString != null) return translatedString;
 
     // If there's no translated string in the locale, record it.
-    if (Translations.recordMissingTranslations)
+    if (Translations.recordMissingTranslations && locale != translations.defaultLocaleStr)
       Translations.missingTranslations.add(TranslatedString(locale: locale, text: key));
     Translations.missingTranslationCallback(key, locale);
 


### PR DESCRIPTION
When using `Translations.byLocale`, we should not need to provide the translations of the default locale like:

```
var t = Translations.byLocale("en_US") +
        {
          "en_us": {
            "Hi.": "Hi.",
            "Goodbye.": "Goodbye.",
          },
        };
```

This is boilerplate.

But if we don't provide it, an error is shown: `➜ There are no translations in 'en_US' for "Hi".`
This behavior should be fixed.

I have created #25 to fix this issue, please take a look of it. Thanks.