### PR TITLE
Add 'getstrings' utility script to export template

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,9 +580,27 @@ Continue developing your app while waiting for the translations. Import the tran
 test the app in each language you added. Repeat the process as needed, translating just the changes between each
 app revision. As necessary, perform additional localization steps yourself.
 
-Importing and exporting is easy to do, because the Translation constructors use maps as input. 
+Importing is easy to do, because the Translation constructors use maps as input. 
 So you can simply generate maps from any file format, 
 and then use the `Translation()` or `Translation.byLocale()` constructors to create the translation objects.
+
+#### Exporting
+
+This package provides a utility script to automatically export all translateable strings from your
+project. Simply run `flutter pub run i18n_extension:getstrings` in your project
+root directory and you will get a list of strings to translate in strings.json. This file can then
+be sent to your translators or be imported in translation services like Crowdin, Transifex or Lokalise.
+You can use it as part of your CI pipeline in order to always have your translation templates up to
+date.
+
+This tool simply searches the source code for strings to which getters like `.i18n` are applied.
+Since it is not very smart, you should not make it too hard for it:
+
+```dart
+print("Hello World!".i18n); // This would work
+var x = "Hello World";
+print(x.i18n); // The tool would not be able to spot this since it doesn't execute the code.
+```
 
 #### Formats
 

--- a/bin/getstrings.dart
+++ b/bin/getstrings.dart
@@ -1,0 +1,22 @@
+import 'dart:collection';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:i18n_extension/i18n_getstrings.dart';
+
+void main(List<String> arguments) async {
+  var parser = ArgParser()
+    ..addOption("output-file", abbr: "f", defaultsTo: "strings.json")
+    ..addOption("source-dir", abbr: "s", defaultsTo: "./lib");
+  var results = parser.parse(arguments);
+  var strings = GetI18nStrings(results["source-dir"]).run();
+  var template = HashMap();
+  for (var s in strings) {
+    template[s] = "";
+  }
+  JsonEncoder encoder = new JsonEncoder.withIndent(' '*4);
+  File(results["output-file"]).writeAsStringSync(encoder.convert(template));
+  print(
+      "Wrote ${strings.length} strings to template ${results["output-file"]}");
+}

--- a/lib/i18n_getstrings.dart
+++ b/lib/i18n_getstrings.dart
@@ -1,0 +1,113 @@
+import 'dart:io';
+
+import 'dart:math';
+
+class GetI18nStrings {
+  final String regexTemplate = '"([^"]*)"\.<getter>';
+  final List<String> stringDelimiters = ["\"", "'", '"""', "'''"];
+  final List<String> suffixes;
+  final String sourceDir;
+
+  GetI18nStrings(this.sourceDir,
+      {this.suffixes = const [
+        ".i18n",
+        ".fill",
+        ".plural",
+        ".version",
+        ".allVersions"
+      ]});
+
+  List<String> run() {
+    var libDir = new Directory(this.sourceDir);
+    List<String> sourceStrings = [];
+    for (var f in libDir.listSync(recursive: true)) {
+      if (f is File && f.path.endsWith(".dart")) {
+        sourceStrings += processFile(f);
+      }
+    }
+    return sourceStrings;
+  }
+
+  List<String> processFile(File f) {
+    return processString(f.readAsStringSync());
+  }
+
+  List<String> processString(String s) {
+    return DartStringParser(s, suffixes).parse();
+  }
+}
+
+class DartStringParser {
+  /// [source] should be Dart code, [suffixes] a list of strings.
+  /// The parser will find all Dart strings within the code that are
+  /// followed by any of the suffixes.
+  ///
+  int pos = 0;
+  List<String> strings = [];
+
+  final String source;
+  final List<String> suffixes;
+
+  DartStringParser(this.source, this.suffixes);
+
+  List<String> parse() {
+    while (seek()) {
+      _parseString();
+    }
+    return strings;
+  }
+
+  void _parseString() {
+    String endSequence;
+    assert(source[pos] == "'" || source[pos] == '"');
+
+    if (source[pos + 1] == source[pos] && source[pos + 2] == source[pos]) {
+      // start triple-quoted string
+      endSequence = source[pos] * 3;
+      pos += 3;
+    } else {
+      // start single-quoted string
+      endSequence = source[pos];
+      pos += 1;
+    }
+
+    int matchPos = -1, _pos = pos;
+    // Make sure this is not an escaped quotation mark (\" or \""")
+    while (matchPos < 0 || source[matchPos - 1] == "\\") {
+      matchPos = source.indexOf(endSequence, _pos);
+      if (matchPos < 0) return;
+      _pos = matchPos + 1;
+    }
+    if (matchPos <= source.length &&
+        suffixes.any((s) =>
+            source.substring(matchPos + endSequence.length).startsWith(s)))
+      strings.add(source.substring(pos, matchPos));
+    pos = matchPos + endSequence.length;
+  }
+
+  bool seek() {
+    List<int> possible = [];
+    int nextOne = source.indexOf("'", pos);
+    int nextTwo = source.indexOf('"', pos);
+
+    if (nextOne > -1) {
+      possible.add(nextOne);
+    }
+
+    if (nextTwo > -1) {
+      possible.add(nextTwo);
+    }
+
+    if (possible.length == 0) {
+      return false;
+    }
+
+    pos = possible.reduce(min);
+
+    if (pos > 0 && source[pos - 1] == "\\" && source[pos - 2] != "\\") {
+      return seek();
+    }
+
+    return true;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   sprintf: ^4.0.2
+  args: ^1.6.0
   flutter:
     sdk: flutter
 

--- a/test/i18n_getstrings_test.dart
+++ b/test/i18n_getstrings_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:i18n_extension/i18n_getstrings.dart';
+
+void main() {
+  test("Simple case", () {
+    var source = """
+    print("This is a test".i18n);
+    print("This should not match");
+    print('This is another %s test'.fill('great'));
+    print('This should not match');
+    """;
+    var results = GetI18nStrings().processString(source);
+    expect(results, ["This is a test", "This is another %s test"]);
+  });
+
+  test("Triple-quoted strings", () {
+    var source = """
+    print("\""This is a
+"test" "\"".i18n);
+    print(""\"This should not match"\"");
+    print('\''This is another test'\''.i18n);
+    print('\''This should not match'\'');
+    """;
+    var results = GetI18nStrings().processString(source);
+    expect(results, ["This is a\n\"test\" ", "This is another test"]);
+  });
+
+  test("Invalid Dart", () {
+    var source = """
+    var y = '''.i18n;
+    var z = '''Hello'''';
+    """;
+    var results = GetI18nStrings().processString(source);
+    expect(results, []);
+  });
+
+  test("Real-world example", () {
+    var source = """
+    import 'package:flutter/material.dart';
+import 'package:settings_ui/settings_ui.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:paperless_app/i18n.dart';
+
+final _scaffoldKey = GlobalKey<ScaffoldState>();
+
+class SettingsRoute extends StatefulWidget {
+  SettingsRoute({Key key}) : super(key: key);
+
+  @override
+  _SettingsRouteState createState() => _SettingsRouteState();
+}
+
+class _SettingsRouteState extends State<SettingsRoute> {
+  bool invertDocumentPreview = true;
+  SharedPreferences prefs;
+  _SettingsRouteState();
+
+
+  @override
+  void initState()  {
+    loadPreferences();
+  }
+
+  void loadPreferences() async {
+    prefs = await SharedPreferences.getInstance();
+    setState(() {
+      invertDocumentPreview = prefs.getBool("invert_document_preview") ?? true;
+    });
+}
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      key: _scaffoldKey,
+      body: SettingsList(
+          sections: [
+            SettingsSection(
+              title: 'View'.i18n,
+              tiles: [
+                SettingsTile.switchTile(
+                  title: 'Invert Document Preview in Dark Mode'.i18n,
+                  leading: Icon(Icons.invert_colors),
+                  switchValue: invertDocumentPreview,
+                  onToggle: (bool value) {
+                    prefs.setBool("invert_document_preview", value);
+                    setState(() {
+                      invertDocumentPreview = value;
+                    });
+                  },
+                ),
+              ],
+            ),
+          ],
+        ),
+    );
+  }
+}""";
+    var results = GetI18nStrings().processString(source);
+    expect(results, ['View', 'Invert Document Preview in Dark Mode']);
+  });
+}


### PR DESCRIPTION
Well, I admit this isn't as clean and easy as I had imagined. Apparently Dart is not a regular language and can thus not be parsed with regexes (I should have paid more attention in those formal languages lectures).

Instead, it uses a hand-crafted parser which handles escaped quotation marks and triple-quoted strings.

I wrote some test cases and also tested it on my own small project. Please let me know if you know any larger projects that use this library.

Closes: #39 