### PR TITLE
Allow multi-line statements in getstrings utility

### DIFF
--- a/lib/i18n_getstrings.dart
+++ b/lib/i18n_getstrings.dart
@@ -78,10 +78,12 @@ class DartStringParser {
       if (matchPos < 0) return;
       _pos = matchPos + 1;
     }
-    if (matchPos <= source.length &&
-        suffixes.any((s) =>
-            source.substring(matchPos + endSequence.length).startsWith(s)))
-      strings.add(source.substring(pos, matchPos));
+    if (matchPos <= source.length) {
+      var start = source.substring(matchPos + endSequence.length).trimLeft();
+      if (suffixes.any((s) => start.startsWith(s)))
+        strings.add(source.substring(pos, matchPos));
+    }
+
     pos = matchPos + endSequence.length;
   }
 

--- a/test/i18n_getstrings_test.dart
+++ b/test/i18n_getstrings_test.dart
@@ -98,4 +98,15 @@ class _SettingsRouteState extends State<SettingsRoute> {
     var results = GetI18nStrings("").processString(source);
     expect(results, ['View', 'Invert Document Preview in Dark Mode']);
   });
+
+  test("Multi-line statements", () {
+    var source = """
+    var y = 'mysamplestring %s'
+      .i18n
+      .fill("test");
+    """;
+    var results = GetI18nStrings("").processString(source);
+    expect(results, ["mysamplestring %s"]);
+  });
 }
+


### PR DESCRIPTION
The utility will now also recognise multi-line statements like

```Dart
'mysamplestring %s'
    .i18n
    .fill("test")
```

Closes: #44