### PR TITLE
Ignore exmpty translation strings for gettext

### DIFF
--- a/lib/io/import.dart
+++ b/lib/io/import.dart
@@ -59,7 +59,7 @@ class GettextImporter extends Importer {
     Map<String, String> out = {};
     var translations = gettextParser.po.parse(source)["translations"][""];
     for (Map translation in translations.values) {
-      if (translation.length > 0)
+      if (translation.length > 0 && translation["msgstr"][0] != "")
         out[translation["msgid"]] = translation["msgstr"][0];
     }
     return out;


### PR DESCRIPTION
Gettext translations usually contain empty strings for untranslated items. Currently, this would cause an `Missing translatedString` error to be raised, causing the import to fail.

This omits empty translations when importing from gettext.