### PR TITLE
Fix nullOk on dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.0-dev.1
+## 3.0.0-dev.1
 
 * Addressed breaking change in Flutter framework (https://github.com/flutter/flutter/pull/68911).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0-dev.1
+
+* Addressed breaking change in Flutter framework (https://github.com/flutter/flutter/pull/68911).
+
 ## [2.0.0] - 2021/30/21
 
 * Plural modifiers: `zeroOne` (for 0 or 1 elements), and `oneOrMore` (for 1 and more elements).

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: example
 description: i18n_extension example
+publish_to: 'none'
 version: 1.0.0+1
 
 environment:

--- a/lib/i18n_widget.dart
+++ b/lib/i18n_widget.dart
@@ -194,7 +194,7 @@ class _I18nState extends State<I18n> {
   }
 
   void _processSystemLocale() {
-    var newSystemLocale = Localizations.localeOf(context, nullOk: true);
+    var newSystemLocale = Localizations.maybeLocaleOf(context);
     if (newSystemLocale != I18n._systemLocale) {
       Locale oldLocale = I18n.locale;
       I18n._systemLocale = newSystemLocale;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: i18n_extension
 description: Translation and Internationalization (i18n) for Flutter. Easy to use for both large and small projects. Uses Dart extensions to reduce boilerplate.
-version: 2.1.0-dev.1
+version: 3.0.0-dev.1
 author: Marcelo Glasberg <marcglasberg@gmail.com>
 homepage: https://github.com/marcglasberg/i18n_extension
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: i18n_extension
 description: Translation and Internationalization (i18n) for Flutter. Easy to use for both large and small projects. Uses Dart extensions to reduce boilerplate.
-version: 2.0.0
+version: 2.1.0-dev.1
 author: Marcelo Glasberg <marcglasberg@gmail.com>
 homepage: https://github.com/marcglasberg/i18n_extension
 


### PR DESCRIPTION
Fixes #66.

See the changelog for directions.

This needs to be a major bump because it is a breaking change. Note that you can simply push future versions onto the `dev` pre-release and it will still be < `3.0.0`. The same could also be done with `-nullsafety` versions (they would also need a major bump because null safety is a breaking change).

@marcglasberg You can publish the version like this and it will create a pre-release on Pub. 