### PR TITLE
add plurals to .POT

### DIFF
--- a/bin/getstrings.dart
+++ b/bin/getstrings.dart
@@ -20,7 +20,7 @@ void main(List<String> arguments) async {
     exit(1);
   }
 
-  var strings = GetI18nStrings(results["source-dir"]).run();
+  List<ExtractedString> strings = GetI18nStrings(results["source-dir"]).run();
 
   var outFile = File(results["output-file"]);
   await outFile.create();

--- a/lib/i18n_getstrings.dart
+++ b/lib/i18n_getstrings.dart
@@ -34,16 +34,16 @@ class ExtractedString extends Equatable {
   List<Object> get props => [string, pluralRequired];
 }
 
-class DecodedSintax {
-  DecodedSintax._({
+class DecodedSyntax {
+  DecodedSyntax._({
     required this.valid,
     this.modifiers = const [],
   });
 
-  DecodedSintax.valid(List<I18nRequiredModifiers> modifiers)
+  DecodedSyntax.valid(List<I18nRequiredModifiers> modifiers)
       : this._(valid: true, modifiers: modifiers);
 
-  DecodedSintax.invalid() : this._(valid: false);
+  DecodedSyntax.invalid() : this._(valid: false);
 
   final bool valid;
   final List<I18nRequiredModifiers> modifiers;
@@ -93,11 +93,11 @@ class StringExtractor extends UnifyingAstVisitor<void> {
 
   @override
   void visitSimpleStringLiteral(SimpleStringLiteral node) {
-    final DecodedSintax sintax = _hasI18nSyntax(node, node.parent!);
-    if (sintax.valid) {
+    final DecodedSyntax syntax = _hasI18nSyntax(node, node.parent!);
+    if (syntax.valid) {
       final ExtractedString s = ExtractedString(node.value,
           pluralRequired:
-              sintax.modifiers.contains(I18nRequiredModifiers.plural));
+              syntax.modifiers.contains(I18nRequiredModifiers.plural));
       strings.add(s);
     }
 
@@ -106,12 +106,12 @@ class StringExtractor extends UnifyingAstVisitor<void> {
 
   @override
   void visitAdjacentStrings(AdjacentStrings node) {
-    final DecodedSintax sintax =
+    final DecodedSyntax syntax =
         _hasI18nSyntax(node.strings.last, node.parent!);
-    if (sintax.valid) {
+    if (syntax.valid) {
       final ExtractedString s = ExtractedString(node.stringValue!,
           pluralRequired:
-              sintax.modifiers.contains(I18nRequiredModifiers.plural));
+              syntax.modifiers.contains(I18nRequiredModifiers.plural));
       strings.add(s);
     }
 
@@ -123,7 +123,7 @@ class StringExtractor extends UnifyingAstVisitor<void> {
   Check if the next sibling in the AST is a DOT operator
   and after that comes a literal included in our suffixes.
    */
-  DecodedSintax _hasI18nSyntax(AstNode self, AstNode parent) {
+  DecodedSyntax _hasI18nSyntax(AstNode self, AstNode parent) {
     Token? here = parent.beginToken;
     while (here != null && here != parent.endToken) {
       if (here == self.beginToken &&
@@ -133,10 +133,10 @@ class StringExtractor extends UnifyingAstVisitor<void> {
         if (here.next!.next!.value() == I18nSuffixes.plural) {
           modifiers.add(I18nRequiredModifiers.plural);
         }
-        return DecodedSintax.valid(modifiers);
+        return DecodedSyntax.valid(modifiers);
       }
       here = here.next;
     }
-    return DecodedSintax.invalid();
+    return DecodedSyntax.invalid();
   }
 }

--- a/lib/i18n_getstrings.dart
+++ b/lib/i18n_getstrings.dart
@@ -2,24 +2,63 @@ import 'dart:io';
 
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:equatable/equatable.dart';
+
+enum I18nRequiredModifiers { plural }
+
+class I18nSuffixes {
+  static const String i18n = 'i18n';
+  static const String fill = 'fill';
+  static const String plural = 'plural';
+  static const String version = 'version';
+  static const String allVersions = 'allVersions';
+
+  static const List<String> allSuffixes = const [
+    i18n,
+    fill,
+    plural,
+    version,
+    allVersions,
+  ];
+}
+
+class ExtractedString extends Equatable {
+  final String string;
+  final bool pluralRequired;
+
+  ExtractedString(this.string, {this.pluralRequired = false});
+
+  @override
+  List<Object> get props => [string, pluralRequired];
+}
+
+class DecodedSintax {
+  DecodedSintax._({
+    required this.valid,
+    this.modifiers = const [],
+  });
+
+  DecodedSintax.valid(List<I18nRequiredModifiers> modifiers)
+      : this._(valid: true, modifiers: modifiers);
+
+  DecodedSintax.invalid() : this._(valid: false);
+
+  final bool valid;
+  final List<I18nRequiredModifiers> modifiers;
+}
 
 class GetI18nStrings {
-  final List<String> suffixes;
   final String? sourceDir;
 
-  GetI18nStrings(this.sourceDir,
-      {this.suffixes = const [
-        "i18n",
-        "fill",
-        "plural",
-        "version",
-        "allVersions"
-      ]});
+  GetI18nStrings(
+    this.sourceDir,
+  );
 
-  List<String> run() {
+  List<ExtractedString> run() {
     var libDir = Directory(sourceDir!);
-    List<String> sourceStrings = [];
+    List<ExtractedString> sourceStrings = [];
     for (var f in libDir.listSync(recursive: true)) {
       if (f is File && f.path.endsWith(".dart")) {
         sourceStrings += processFile(f);
@@ -28,22 +67,21 @@ class GetI18nStrings {
     return sourceStrings;
   }
 
-  List<String> processFile(File f) {
+  List<ExtractedString> processFile(File f) {
     return processString(f.readAsStringSync());
   }
 
-  List<String> processString(String s) {
+  List<ExtractedString> processString(String s) {
     CompilationUnit unit =
         parseString(content: s, throwIfDiagnostics: false).unit;
-    var extractor = StringExtractor(suffixes);
+    var extractor = StringExtractor(I18nSuffixes.allSuffixes);
     unit.visitChildren(extractor);
     return extractor.strings;
   }
 }
 
-
 class StringExtractor extends UnifyingAstVisitor<void> {
-  List<String> strings = [];
+  List<ExtractedString> strings = [];
   List<String> suffixes;
 
   StringExtractor(this.suffixes);
@@ -55,8 +93,12 @@ class StringExtractor extends UnifyingAstVisitor<void> {
 
   @override
   void visitSimpleStringLiteral(SimpleStringLiteral node) {
-    if (_hasI18nSyntax(node, node.parent!)) {
-      strings.add(node.value);
+    final DecodedSintax sintax = _hasI18nSyntax(node, node.parent!);
+    if (sintax.valid) {
+      final ExtractedString s = ExtractedString(node.value,
+          pluralRequired:
+              sintax.modifiers.contains(I18nRequiredModifiers.plural));
+      strings.add(s);
     }
 
     return super.visitSimpleStringLiteral(node);
@@ -64,8 +106,13 @@ class StringExtractor extends UnifyingAstVisitor<void> {
 
   @override
   void visitAdjacentStrings(AdjacentStrings node) {
-    if (_hasI18nSyntax(node.strings.last, node.parent!)) {
-      strings.add(node.stringValue!);
+    final DecodedSintax sintax =
+        _hasI18nSyntax(node.strings.last, node.parent!);
+    if (sintax.valid) {
+      final ExtractedString s = ExtractedString(node.stringValue!,
+          pluralRequired:
+              sintax.modifiers.contains(I18nRequiredModifiers.plural));
+      strings.add(s);
     }
 
     // Dont' call the super method here, since we don't want to visit the
@@ -76,16 +123,20 @@ class StringExtractor extends UnifyingAstVisitor<void> {
   Check if the next sibling in the AST is a DOT operator
   and after that comes a literal included in our suffixes.
    */
-  bool _hasI18nSyntax(AstNode self, AstNode parent) {
-    var here = parent.beginToken;
-    while (here != parent.endToken) {
+  DecodedSintax _hasI18nSyntax(AstNode self, AstNode parent) {
+    Token? here = parent.beginToken;
+    while (here != null && here != parent.endToken) {
       if (here == self.beginToken &&
           here.next!.type.lexeme == "." &&
           suffixes.contains(here.next!.next!.value())) {
-        return true;
+        List<I18nRequiredModifiers> modifiers = List.empty(growable: true);
+        if (here.next!.next!.value() == I18nSuffixes.plural) {
+          modifiers.add(I18nRequiredModifiers.plural);
+        }
+        return DecodedSintax.valid(modifiers);
       }
-      here = here.next!;
+      here = here.next;
     }
-    return false;
+    return DecodedSintax.invalid();
   }
 }

--- a/lib/i18n_getstrings.dart
+++ b/lib/i18n_getstrings.dart
@@ -93,19 +93,14 @@ class StringExtractor extends UnifyingAstVisitor<void> {
 
   @override
   void visitSimpleStringLiteral(SimpleStringLiteral node) {
-    final DecodedSyntax syntax = _hasI18nSyntax(node, node.parent!);
-    if (syntax.valid) {
-      final ExtractedString s = ExtractedString(node.value,
-          pluralRequired:
-              syntax.modifiers.contains(I18nRequiredModifiers.plural));
-      strings.add(s);
-    }
-
+    _handleI18nSyntax(node);
     return super.visitSimpleStringLiteral(node);
   }
 
   @override
   void visitAdjacentStrings(AdjacentStrings node) {
+    _handleI18nSyntax(node);
+
     final DecodedSyntax syntax =
         _hasI18nSyntax(node.strings.last, node.parent!);
     if (syntax.valid) {
@@ -117,6 +112,16 @@ class StringExtractor extends UnifyingAstVisitor<void> {
 
     // Dont' call the super method here, since we don't want to visit the
     // child strings.
+  }
+
+  void _handleI18nSyntax(StringLiteral node) {
+    final DecodedSyntax syntax = _hasI18nSyntax(node, node.parent!);
+    if (syntax.valid && node.stringValue != null) {
+      final ExtractedString s = ExtractedString(node.stringValue!,
+          pluralRequired:
+              syntax.modifiers.contains(I18nRequiredModifiers.plural));
+      strings.add(s);
+    }
   }
 
   /*

--- a/lib/io/export.dart
+++ b/lib/io/export.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:gettext_parser/gettext_parser.dart' as gettext_parser;
 
+import '../i18n_getstrings.dart';
+
 Map<String, Exporter Function(dynamic)> exporters = {
   "pot": (s) => GettextExporter(s),
   "json": (s) => JsonExporter(s)
@@ -12,33 +14,38 @@ abstract class Exporter {
   HashMap<String, String> getTemplate() {
     HashMap<String, String> template = HashMap();
     for (var s in sourceStrings) {
-      template[s] = "";
+      template[s.string] = "";
     }
     return template;
   }
 
-  List<String> sourceStrings;
+  List<ExtractedString> sourceStrings;
   Exporter(this.sourceStrings);
   Future<void> exportTo(File target);
 }
 
 class GettextExporter extends Exporter {
-  GettextExporter(List<String> sourceStrings) : super(sourceStrings);
+  GettextExporter(List<ExtractedString> sourceStrings) : super(sourceStrings);
 
   @override
   Future<void> exportTo(File target) async {
-    Map<String, dynamic> template = {};
+    Map<String, Map<String, dynamic>> template = {};
 
     for (var string in sourceStrings) {
-      template[string] = {
-        "msgid": string,
-        "msgstr": [""]
+      template[string.string] = {
+        "msgid": string.string,
       };
+      template[string.string]?["msgstr"] = [""];
+      if (string.pluralRequired) {
+        template[string.string]?["msgid_plural"] = string.string;
+      }
     }
 
     Map out = {
       "charset": "utf-8",
-      "headers": {"content-type": "text/plain; charset=utf-8"},
+      "headers": {
+        "content-type": "text/plain; charset=utf-8; nplurals=2; plural=(n != 1)"
+      },
       "translations": {"": template}
     };
 
@@ -47,11 +54,11 @@ class GettextExporter extends Exporter {
 }
 
 class JsonExporter extends Exporter {
-  JsonExporter(List<String> sourceStrings) : super(sourceStrings);
+  JsonExporter(List<ExtractedString> sourceStrings) : super(sourceStrings);
 
   @override
   Future<void> exportTo(File target) async {
-    JsonEncoder encoder =JsonEncoder.withIndent(' ' * 4);
+    JsonEncoder encoder = JsonEncoder.withIndent(' ' * 4);
     await target.writeAsString(encoder.convert(getTemplate()));
   }
 }

--- a/lib/io/import.dart
+++ b/lib/io/import.dart
@@ -82,6 +82,10 @@ class GettextImporter extends Importer {
             out[msgid] = _splitter1 +
                 translation["msgstr"][0] +
                 _splitter1 +
+                '1' +
+                _splitter2 +
+                translation["msgstr"][0] +
+                _splitter1 +
                 'M' +
                 _splitter2 +
                 translation["msgstr"][1];

--- a/lib/io/import.dart
+++ b/lib/io/import.dart
@@ -57,6 +57,8 @@ class JSONImporter extends Importer {
 }
 
 // /////////////////////////////////////////////////////////////////////////////
+const _splitter1 = "\uFFFF";
+const _splitter2 = "\uFFFE";
 
 class GettextImporter extends Importer {
   @override
@@ -68,10 +70,21 @@ class GettextImporter extends Importer {
     Map translations = gettext_parser.po.parse(source)["translations"][""];
     for (Map translation in translations.values) {
       if (translation.isNotEmpty) {
-        String? msgstr = translation["msgstr"][0];
-        if (msgstr != null && msgstr.isNotEmpty) {
+        if (translation["msgstr"].length == 1) {
+          String? msgstr = translation["msgstr"][0];
+          if (msgstr != null && msgstr.isNotEmpty) {
+            String? msgid = translation["msgid"];
+            if (msgid != null && msgid.isNotEmpty) out[msgid] = msgstr;
+          }
+        } else {
           String? msgid = translation["msgid"];
-          if (msgid != null && msgid.isNotEmpty) out[msgid] = msgstr;
+          if (msgid != null && msgid.isNotEmpty)
+            out[msgid] = _splitter1 +
+                translation["msgstr"][0] +
+                _splitter1 +
+                'M' +
+                _splitter2 +
+                translation["msgstr"][1];
         }
       }
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: i18n_extension
 description: Translation and Internationalization (i18n) for Flutter. Easy to use for both large and small projects. Uses Dart extensions to reduce boilerplate.
-version: 4.0.0
+version: 4.0.1
 author: Marcelo Glasberg <marcglasberg@gmail.com>
 homepage: https://github.com/marcglasberg/i18n_extension
 
@@ -12,8 +12,10 @@ dependencies:
   args: ^2.0.0
   analyzer: ^1.1.0
   gettext_parser: ^0.2.0
+  equatable: ^2.0.0
   flutter:
     sdk: flutter
+  
 
 dev_dependencies:
   flutter_test:

--- a/test/fixtures/strings-de.po
+++ b/test/fixtures/strings-de.po
@@ -22,7 +22,9 @@ msgid "Edit Server Details"
 msgstr "Serverdetails bearbeiten"
 
 msgid "Error while uploading document"
-msgstr "Fehler beim Hochladen des Dokuments"
+msgid_plural "Error while uploading document"
+msgstr[0] "Fehler beim Hochladen des Dokument"
+msgstr[1] "Fehler beim Hochladen des Dokuments"
 
 msgid "My Documents"
 msgstr "Meine Dokumente"

--- a/test/i18n_getstrings_test.dart
+++ b/test/i18n_getstrings_test.dart
@@ -12,7 +12,10 @@ void main() {
     }
     """;
     var results = GetI18nStrings("").processString(source);
-    expect(results, ["This is a test", "This is another %s test"]);
+    expect(
+        results,
+        ["This is a test", "This is another %s test"]
+            .map((e) => ExtractedString(e)));
   });
 
   test("Triple-quoted strings", () {
@@ -26,7 +29,10 @@ void main() {
     }
     """;
     var results = GetI18nStrings("").processString(source);
-    expect(results, ["This is a\n\"test\" ", "This is another test"]);
+    expect(
+        results,
+        ["This is a\n\"test\" ", "This is another test"]
+            .map((e) => ExtractedString(e)));
   });
 
   test("Invalid Dart", () {
@@ -36,6 +42,41 @@ void main() {
     """;
     var results = GetI18nStrings("").processString(source);
     expect(results, []);
+  });
+
+  test("Plurals in .POT", () {
+    var source = """
+    return Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: TranslatableRichText(
+                    Text(
+                      '''%s order on %s'''.plural(_orders!.length).fill(
+                        <String>[
+                          _orders!.length.toStringAsFixed(
+                            0,
+                          ),
+                          formattedPickup
+                        ],
+                      ),
+                    ),
+                    richTexts: <BaseRichText>[
+                      BaseRichText(
+                        text: '%s order'
+                            .plural(_orders!.length)
+                            .fill(<String>[_orders!.length.toStringAsFixed(0)]),
+                        style: AppTextStyles.vocalOrderBoldTitle.copyWith(
+                          color: AppColors.vocalOrderErrorColor,
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+    """;
+    var results = GetI18nStrings("").processString(source);
+    expect(results, [
+      ExtractedString('%s order on %s', pluralRequired: true),
+      ExtractedString('%s order', pluralRequired: true)
+    ]);
   });
 
   test("Real-world example", () {
@@ -100,7 +141,10 @@ class _SettingsRouteState extends State<SettingsRoute> {
   }
 }""";
     var results = GetI18nStrings("").processString(source);
-    expect(results, ['View', 'Invert Document Preview in Dark Mode']);
+    expect(
+        results,
+        ['View', 'Invert Document Preview in Dark Mode']
+            .map((e) => ExtractedString(e)));
   });
 
   test("Multi-line statements", () {
@@ -110,7 +154,7 @@ class _SettingsRouteState extends State<SettingsRoute> {
       .fill("test");
     """;
     var results = GetI18nStrings("").processString(source);
-    expect(results, ["mysamplestring %s"]);
+    expect(results, ["mysamplestring %s"].map((e) => ExtractedString(e)));
   });
 
   test("Simple case with comments", () {
@@ -124,7 +168,10 @@ class _SettingsRouteState extends State<SettingsRoute> {
     }
     """;
     var results = GetI18nStrings("").processString(source);
-    expect(results, ["This is a test", "This is another %s test"]);
+    expect(
+        results,
+        ["This is a test", "This is another %s test"]
+            .map((e) => ExtractedString(e)));
   });
 
   test("Simple case with adjacent strings", () {
@@ -137,8 +184,10 @@ class _SettingsRouteState extends State<SettingsRoute> {
                "at all.";     
     """;
     var results = GetI18nStrings("").processString(source);
-    expect(results, [
-      "This should be a single string, hopefully it doesn't just recognise the last part."
-    ]);
+    expect(
+        results,
+        [
+          "This should be a single string, hopefully it doesn't just recognise the last part."
+        ].map((e) => ExtractedString(e)));
   });
 }

--- a/test/import_test.dart
+++ b/test/import_test.dart
@@ -19,6 +19,13 @@ void main() {
     var myTranslations = Translations.byLocale("en_gb") + translation;
     expect(myTranslations.translations.length, 30);
     expect(localize("View", myTranslations, locale: "de"), "Ansicht");
+    expect(
+        localizePlural(1, "Error while uploading document", myTranslations,
+            locale: "de"),
+        "Fehler beim Hochladen des Dokument");
+    expect(
+        localizePlural(2, "Error while uploading document", myTranslations,
+            locale: "de"),
+        "Fehler beim Hochladen des Dokuments");
   });
 }
-

--- a/test/import_test.dart
+++ b/test/import_test.dart
@@ -20,6 +20,10 @@ void main() {
     expect(myTranslations.translations.length, 30);
     expect(localize("View", myTranslations, locale: "de"), "Ansicht");
     expect(
+        localizePlural(0, "Error while uploading document", myTranslations,
+            locale: "de"),
+        "Fehler beim Hochladen des Dokuments");
+    expect(
         localizePlural(1, "Error while uploading document", myTranslations,
             locale: "de"),
         "Fehler beim Hochladen des Dokument");


### PR DESCRIPTION
Adding plural suport for .POT export. The compiler was already working. I added a structure to report the request from plural in code to the extracting function.