### PR TITLE
In Flutter 3.10.0-7.0.pre.18, flutter_localizations (from sdk) depends on intl: ^0.18

### DIFF
--- a/lib/i18n_extension.dart
+++ b/lib/i18n_extension.dart
@@ -667,7 +667,7 @@ extension Localization on String {
   //
   String modifier(Object identifier, String text) {
     return ((!startsWith(_splitter1)) ? _splitter1 : "") +
-        "${this}$_splitter1$identifier$_splitter2$text";
+        "$this$_splitter1$identifier$_splitter2$text";
   }
 
   /// Plural modifier for zero elements.

--- a/lib/i18n_getstrings.dart
+++ b/lib/i18n_getstrings.dart
@@ -91,10 +91,6 @@ class StringExtractor extends UnifyingAstVisitor<void> {
 
   StringExtractor(this.suffixes, this.source, this.fileName);
 
-  @override
-  void visitNode(AstNode node) {
-    return super.visitNode(node);
-  }
 
   @override
   void visitSimpleStringLiteral(SimpleStringLiteral node) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   analyzer: ^5.3.1
   gettext_parser: ^0.2.0
   equatable: ^2.0.5
-  intl: ^0.17.0
+  intl: ^0.18.0
   flutter:
     sdk: flutter
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   analyzer: ^5.3.1
   gettext_parser: ^0.2.0
   equatable: ^2.0.5
-  intl: ^0.18.0
+  intl: ^0.17.0
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
In the latest flutter flutter_localizations (from sdk) depends on intl: ^0.18.0.
The other fixes where suggested by 'flutter fix'.